### PR TITLE
fix web interface cue grid being unresponsive to cue cell clicks

### DIFF
--- a/resources/public/js/show_updates.js
+++ b/resources/public/js/show_updates.js
@@ -586,7 +586,7 @@ function metronomeAdjustClicked( eventObject ) {
 var $doc = $(document);
 
 function cueCellClicked( eventObject ) {
-    if (event.which != 1) {
+    if (eventObject.originalEvent.which != 1) {
         return;  // Only respond to ordinary, left-button clicks.
     }
     var cell = this.id;


### PR DESCRIPTION
the web interface cue grid calls an undefined reference "event" in the cueCellClicked callback.
i'm no js expert, but this fixes it for me.